### PR TITLE
Added rule to force using FQCN in DocBlock comments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "friendsofphp/php-cs-fixer": "^2.17"
+        "friendsofphp/php-cs-fixer": "^2.17",
+        "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^1.1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/src/lib/PhpCsFixer/EzPlatformInternalConfigFactory.php
+++ b/src/lib/PhpCsFixer/EzPlatformInternalConfigFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformCodeStyle\PhpCsFixer;
 
+use AdamWojs\PhpCsFixerPhpdocForceFQCN\Fixer\Phpdoc\ForceFQCNFixer;
 use PhpCsFixer\ConfigInterface;
 
 /**
@@ -25,6 +26,9 @@ EOF;
     public static function build(): ConfigInterface
     {
         $config = new Config();
+        $config->registerCustomFixers([
+            new ForceFQCNFixer(),
+        ]);
 
         $specificRules = [
             'header_comment' => [
@@ -33,6 +37,7 @@ EOF;
                 'location' => 'after_open',
                 'separate' => 'top',
             ],
+            'AdamWojs/phpdoc_force_fqcn_fixer' => true,
         ];
         $config->setRules(array_merge($config->getRules(), $specificRules));
 


### PR DESCRIPTION
> JIRA: -

### Description

Added rule to force using FQCN in DocBlock comments.