### PR TITLE
Enforced strict type declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4.x-dev"
+            "dev-master": "1.0.x-dev"
         }
     }
 }

--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -18,6 +18,7 @@ class Config extends ConfigBase
 
         $this->setRiskyAllowed(true);
         $this->setRules([
+            'declare_strict_types' => true,
             'encoding' => true,
             'full_opening_tag' => true,
             'blank_line_after_namespace' => true,
@@ -159,7 +160,7 @@ class Config extends ConfigBase
             'phpdoc_to_comment' => false,
             'cast_spaces' => false,
             'blank_line_after_opening_tag' => false,
-            'single_blank_line_before_namespace' => false,
+            'single_blank_line_before_namespace' => true,
             'space_after_semicolon' => false,
             'native_function_invocation' => false,
             'phpdoc_types_order' => [

--- a/src/lib/PhpCsFixer/EzPlatformInternalConfigFactory.php
+++ b/src/lib/PhpCsFixer/EzPlatformInternalConfigFactory.php
@@ -24,7 +24,7 @@ EOF;
 
     public static function build(): ConfigInterface
     {
-        $config = Config::create();
+        $config = new Config();
 
         $specificRules = [
             'header_comment' => [


### PR DESCRIPTION
> JIRA: -

### Description

Added rule enforce declare strict types in default ruleset.

Also, changed deprecated `Config` instantiation (`Config::create` is deprecated since 2.17).

