### PR TITLE
Fixed too strict code style vs. phpdoc_tag_type causing conflict with phpstan declarations

### DIFF
--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -97,7 +97,11 @@ class Config extends ConfigBase
             'phpdoc_annotation_without_dot' => false,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => true,
-            'phpdoc_tag_type' => true,
+            'phpdoc_tag_type' => [
+                'tags' => [
+                    'inheritdoc' => 'inline',
+                ],
+            ],
             'general_phpdoc_tag_rename' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug
| **Target package version** | ?
| **BC breaks**                          | no
| **Doc needed**                       | no

Relaxes the requirement for phpdoc's.

PHPStan often uses `/** @var array<array{something: bool}> */` notation, which our current settings for code style would happily strip of the ending `}` sign. This causes the declaration to become invalid.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
