### PR TITLE
Allowed class definition to span multiple lines

### DIFF
--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -50,7 +50,6 @@ class Config extends ConfigBase
                 'allow_single_line_closure' => true,
             ],
             'class_attributes_separation' => ['elements' => ['method' => 'one']],
-            'class_definition' => ['single_line' => true],
             'declare_equal_normalize' => true,
             'function_typehint_space' => true,
             'include' => true,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target package version** | ?
| **BC breaks**                          | no
| **Doc needed**                       | no

As in title. Some classes in our codebase implement multiple interfaces, which causes line length to exceed the soft limit.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
