### PR TITLE
Allowed usage with newer version of PHP-CS-Fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,18 @@ to contributions, etc.
 
 ### Third party packages
 
-Create a `.php_cs` file in your project root directory with the following content:
+Create a `.php-cs-fixer.php` file in your project root directory with the following content:
 
 ```php
 <?php
 
-$config = new EzSystems\EzPlatformCodeStyle\PhpCsFixer\Config();
+$factory = new Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory();
+
+// You can omit the call below if you want Ibexa ruleset with no custom rules
+$factory->withRules([
+    // Your rules go here
+]);
+$config = Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory::buildConfig();
 $config->setFinder(
     PhpCsFixer\Finder::create()
         ->in(__DIR__ . '/src')
@@ -26,12 +32,12 @@ return $config;
 
 ### Ibexa packages
 
-Create a `.php_cs` file in your project root directory with the following content:
+Create a `.php-cs-fixer.php` file in your project root directory with the following content:
 
 ```php
 <?php
 
-return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
+return Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory::build()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__ . '/src')

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $factory = new Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory();
 $factory->withRules([
     // Your rules go here
 ]);
-$config = Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory::buildConfig();
+$config = $factory->buildConfig();
 $config->setFinder(
     PhpCsFixer\Finder::create()
         ->in(__DIR__ . '/src')

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.1",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^1.1"
+        "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^1.2"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.1",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^1.2"
+        "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target package version** | ?
| **BC breaks**                          | :exclamation: **yes** :exclamation: 
| **Doc needed**                       | no

Allows installation with `3.0` of `php-cs-fixer`.

Since we've removed the deprecations, we're more than ready to mark this package as compatible with 3.0.

### To prevent issues with current packages that rely on `1.0` of this package, and can potentially have invalid code style check declarations (some deprecations are tied directly to php-cs-fixer call) I'd suggest making this a 2.0 release.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
