### PR TITLE
Added new configuration to enforce empty line between class properties

### DIFF
--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -49,7 +49,12 @@ class Config extends ConfigBase
             'braces' => [
                 'allow_single_line_closure' => true,
             ],
-            'class_attributes_separation' => ['elements' => ['method' => 'one']],
+            'class_attributes_separation' => [
+                'elements' => [
+                    'method' => 'one',
+                    'property' => 'one',
+                ],
+            ],
             'declare_equal_normalize' => true,
             'function_typehint_space' => true,
             'include' => true,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target package version** | master
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR  adds a new configuration value to enforce empty line between class properties

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
